### PR TITLE
feature/staticTypeField_IRIs

### DIFF
--- a/owl-orm-api/src/main/java/com/realmone/owl/orm/Thing.java
+++ b/owl-orm-api/src/main/java/com/realmone/owl/orm/Thing.java
@@ -7,6 +7,7 @@
  */
 package com.realmone.owl.orm;
 
+import com.realmone.owl.orm.annotations.Type;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
@@ -19,6 +20,7 @@ import java.util.Set;
  * A class that represents a owl Thing. Basically a base structure for all things in the
  * owl ontology universe to extend.
  */
+@Type("http://www.w3.org/2002/07/owl#Thing")
 public interface Thing {
 
     /**

--- a/owl-orm-api/src/main/java/com/realmone/owl/orm/VocabularyIRIs.java
+++ b/owl-orm-api/src/main/java/com/realmone/owl/orm/VocabularyIRIs.java
@@ -1,0 +1,13 @@
+package com.realmone.owl.orm;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.base.InternedIRI;
+
+public class VocabularyIRIs {
+    private VocabularyIRIs() {
+    }
+
+    public static IRI createIRI(String namespace, String localName) {
+        return new InternedIRI(namespace, localName);
+    }
+}

--- a/owl-orm-api/src/main/java/com/realmone/owl/orm/VocabularyIRIs.java
+++ b/owl-orm-api/src/main/java/com/realmone/owl/orm/VocabularyIRIs.java
@@ -1,5 +1,6 @@
 package com.realmone.owl.orm;
 
+import lombok.experimental.UtilityClass;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.base.InternedIRI;
 
@@ -7,9 +8,8 @@ import org.eclipse.rdf4j.model.base.InternedIRI;
  * A utility class to create IRIs for use in generated interfaces so clients can do things like `Beer.TYPE` to get the
  * IRI of the Beer class or `Beer.ALCOHOLBYVOLUME` to get the IRI of the alcoholByVolume property.
  */
+@UtilityClass
 public class VocabularyIRIs {
-    private VocabularyIRIs() {
-    }
 
     public static IRI createIRI(String namespace, String localName) {
         return new InternedIRI(namespace, localName);

--- a/owl-orm-api/src/main/java/com/realmone/owl/orm/VocabularyIRIs.java
+++ b/owl-orm-api/src/main/java/com/realmone/owl/orm/VocabularyIRIs.java
@@ -3,6 +3,10 @@ package com.realmone.owl.orm;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.base.InternedIRI;
 
+/**
+ * A utility class to create IRIs for use in generated interfaces so clients can do things like `Beer.TYPE` to get the
+ * IRI of the Beer class or `Beer.ALCOHOLBYVOLUME` to get the IRI of the alcoholByVolume property.
+ */
 public class VocabularyIRIs {
     private VocabularyIRIs() {
     }

--- a/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/GeneratingOntology.java
+++ b/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/GeneratingOntology.java
@@ -129,6 +129,8 @@ public class GeneratingOntology extends AbstractOntology {
             try {
                 JDefinedClass clazz = (JDefinedClass) classIndex.get(classResource);
                 // Add the type IRI/resource to the class as a static field
+                clazz.field(JMod.STATIC, String.class, "TYPE_STR", JExpr.lit(classResource.stringValue()))
+                        .javadoc().add("The String value of the rdf:type that identifies this class.");
                 if (classResource.isIRI()) {
                     IRI classIRI = (IRI) classResource;
                     clazz.field(JMod.STATIC, IRI.class, "TYPE", jPackage.owner().ref(VocabularyIRIs.class)

--- a/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/GeneratingOntology.java
+++ b/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/GeneratingOntology.java
@@ -9,16 +9,25 @@ package com.realmone.owl.orm.generate;
 
 import com.realmone.owl.orm.OrmException;
 import com.realmone.owl.orm.Thing;
+import com.realmone.owl.orm.VocabularyIRIs;
 import com.realmone.owl.orm.annotations.Type;
 import com.realmone.owl.orm.generate.properties.DatatypeProperty;
 import com.realmone.owl.orm.generate.properties.ObjectProperty;
 import com.realmone.owl.orm.generate.support.GraphUtils;
 import com.realmone.owl.orm.generate.support.NamingUtilities;
-import com.sun.codemodel.*;
+import com.sun.codemodel.JClass;
+import com.sun.codemodel.JClassAlreadyExistsException;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JDocComment;
+import com.sun.codemodel.JExpr;
+import com.sun.codemodel.JMod;
+import com.sun.codemodel.JPackage;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
@@ -115,8 +124,14 @@ public class GeneratingOntology extends AbstractOntology {
             try {
                 JDefinedClass clazz = (JDefinedClass) classIndex.get(classResource);
                 // Add the type IRI/resource to the class as a static field
-                clazz.field(JMod.STATIC, String.class, "TYPE", JExpr.lit(classResource.stringValue()))
-                        .javadoc().add("The String value of the rdf:type IRI that identifies this class.");
+                if (classResource.isIRI()) {
+                    IRI classIRI = (IRI) classResource;
+                    clazz.field(JMod.STATIC, IRI.class, "TYPE", jPackage.owner().ref(VocabularyIRIs.class)
+                                    .staticInvoke("createIRI")
+                                    .arg(classIRI.getNamespace())
+                                    .arg(classIRI.getLocalName()))
+                            .javadoc().add("The IRI value of the rdf:type that identifies this class.");
+                }
                 parents.forEach(parentResource -> {
                     JClass ref = findClassReference(parentResource)
                             //TODO - better error message

--- a/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/GeneratingOntology.java
+++ b/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/GeneratingOntology.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 public class GeneratingOntology extends AbstractOntology {
@@ -112,7 +113,11 @@ public class GeneratingOntology extends AbstractOntology {
                 .map(this::toResource).forEach(imports::add);
         // Add all class resources to our index.
         // TODO - RDFS.CLASS support?
-        classIris.addAll(model.filter(null, RDF.TYPE, OWL.CLASS).subjects());
+        classIris.addAll(model.filter(null, RDF.TYPE, OWL.CLASS).subjects()
+                .stream()
+                .filter(Resource::isIRI) // Don't create interfaces for blank node classes (usually Restrictions)
+                .collect(Collectors.toSet())
+        );
         // Build our hierarchy index map.
         classIris.forEach(classResource -> {
             classIndex.put(classResource, generateInterface(classResource));

--- a/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/properties/DatatypeProperty.java
+++ b/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/properties/DatatypeProperty.java
@@ -39,7 +39,7 @@ public class DatatypeProperty extends Property {
     }
 
     @Override
-    public void additionalAttach(JDefinedClass jDefinedClass) throws OrmGenerationException {
+    public void additionalAttach(JDefinedClass jDefinedClass, String suffix) throws OrmGenerationException {
 
 
     }

--- a/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/properties/ObjectProperty.java
+++ b/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/properties/ObjectProperty.java
@@ -33,7 +33,7 @@ public class ObjectProperty extends Property {
     }
 
     @Override
-    public void additionalAttach(JDefinedClass jDefinedClass) throws OrmGenerationException {
+    public void additionalAttach(JDefinedClass jDefinedClass, String suffix) throws OrmGenerationException {
 
     }
 

--- a/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/properties/Property.java
+++ b/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/properties/Property.java
@@ -39,40 +39,42 @@ public abstract class Property {
     protected Set<Resource> domain;
     protected String commentContext;
 
-    protected abstract void additionalAttach(JDefinedClass jDefinedClass) throws OrmGenerationException;
+    protected abstract void additionalAttach(JDefinedClass jDefinedClass, String suffix) throws OrmGenerationException;
 
     public void attach(JDefinedClass jDefinedClass) throws OrmGenerationException {
         // Add IRI field
-        if (resource.isIRI()) {
-            IRI propIRI = (IRI) resource;
+        int counter = 0;
+        if (resource instanceof IRI propIRI) {
             String staticFieldName = javaName.toUpperCase();
-            if (jDefinedClass.fields().containsKey(staticFieldName)) {
-                staticFieldName += "1";
+            while (jDefinedClass.fields().containsKey(staticFieldName + getSuffix(counter))) {
+                counter++;
             }
-            jDefinedClass.field(JMod.STATIC, IRI.class, staticFieldName, jCodeModel.ref(VocabularyIRIs.class).staticInvoke("createIRI")
-                            .arg(propIRI.getNamespace())
-                            .arg(propIRI.getLocalName()))
+            staticFieldName += getSuffix(counter);
+            jDefinedClass.field(JMod.STATIC, IRI.class, staticFieldName,
+                            jCodeModel.ref(VocabularyIRIs.class).staticInvoke("createIRI").arg(propIRI.getNamespace())
+                                    .arg(propIRI.getLocalName()))
                     .javadoc().add("The IRI value of the " + resource + " property");
         }
+        String suffix = getSuffix(counter);
         // Build methods...
-        createGetter(jDefinedClass);
-        createSetter(jDefinedClass);
-        createClearOutMethod(jDefinedClass);
+        createGetter(jDefinedClass, suffix);
+        createSetter(jDefinedClass, suffix);
+        createClearOutMethod(jDefinedClass, suffix);
         // addTo, removeFrom, clearOut on non-functional fields
         if (!functional) {
-            createAddRemoveMethod(jDefinedClass, true);
-            createAddRemoveMethod(jDefinedClass, false);
+            createAddRemoveMethod(jDefinedClass, true, suffix);
+            createAddRemoveMethod(jDefinedClass, false, suffix);
 //            createClearOutMethod(jDefinedClass);
         }
-        additionalAttach(jDefinedClass);
+        additionalAttach(jDefinedClass, suffix);
     }
 
-    private void createGetter(JDefinedClass jDefinedClass) {
+    private void createGetter(JDefinedClass jDefinedClass, String suffix) {
         JMethod method = jDefinedClass.method(JMod.PUBLIC,
                 functional ? jCodeModel.ref(Optional.class).narrow(targetRange)
                         : jCodeModel.ref(Set.class).narrow(targetRange),
-                String.format("%s%s", functional && targetRange.fullName().equals(Boolean.class.getName()) ? "is"
-                        : "get", javaName));
+                String.format("%s%s%s", functional && targetRange.fullName().equals(Boolean.class.getName()) ? "is"
+                        : "get", javaName, suffix));
         annotateMethod(method, targetRange.dotclass());
         JDocComment docs = method.javadoc();
 
@@ -85,8 +87,8 @@ public abstract class Property {
                 : "The set of values from the underlying graph model");
     }
 
-    private void createSetter(JDefinedClass jDefinedClass) {
-        JMethod method = jDefinedClass.method(JMod.PUBLIC, jCodeModel.VOID, String.format("set%s", javaName));
+    private void createSetter(JDefinedClass jDefinedClass, String suffix) {
+        JMethod method = jDefinedClass.method(JMod.PUBLIC, jCodeModel.VOID, String.format("set%s%s", javaName, suffix));
         JVar parameter = method.param(functional ? targetRange : jCodeModel.ref(Set.class).narrow(targetRange),
                 functional ? "value" : "values");
         annotateMethod(method, targetRange.dotclass());
@@ -100,9 +102,9 @@ public abstract class Property {
                 : "The set of values to associate with this property for this instance");
     }
 
-    private void createAddRemoveMethod(JDefinedClass jDefinedClass, boolean add) {
-        JMethod method = jDefinedClass.method(JMod.PUBLIC, jCodeModel.BOOLEAN, String.format("%s%s", add ? "addTo"
-                : "removeFrom", javaName));
+    private void createAddRemoveMethod(JDefinedClass jDefinedClass, boolean add, String suffix) {
+        JMethod method = jDefinedClass.method(JMod.PUBLIC, jCodeModel.BOOLEAN, String.format("%s%s%s", add ? "addTo"
+                : "removeFrom", javaName, suffix));
         JVar parameter = method.param(targetRange, add ? "toAdd" : "toRemove");
         annotateMethod(method, targetRange.dotclass());
         JDocComment docs = method.javadoc();
@@ -117,8 +119,9 @@ public abstract class Property {
                 : "Whether the value was removed from the set of data");
     }
 
-    public void createClearOutMethod(JDefinedClass jDefinedClass) {
-        JMethod method = jDefinedClass.method(JMod.PUBLIC, jCodeModel.BOOLEAN, String.format("clearOut%s", javaName));
+    public void createClearOutMethod(JDefinedClass jDefinedClass, String suffix) {
+        JMethod method = jDefinedClass.method(JMod.PUBLIC, jCodeModel.BOOLEAN, String.format("clearOut%s%s", javaName,
+                suffix));
         annotateMethod(method, targetRange.dotclass());
         JDocComment docs = method.javadoc();
         docs.add(String.format("<p>Clear out all values associated with property <b>%s</b>.</p><br>",
@@ -132,5 +135,9 @@ public abstract class Property {
                 .param("value", resource.stringValue())
                 .param("functional", functional)
                 .param("type", rangeClass);
+    }
+
+    private String getSuffix(int counter) {
+        return counter == 0 ? "" : String.valueOf(counter);
     }
 }

--- a/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/support/GraphUtils.java
+++ b/owl-orm-generate/src/main/java/com/realmone/owl/orm/generate/support/GraphUtils.java
@@ -64,6 +64,7 @@ public class GraphUtils {
             return model.filter(classResource, RDFS.SUBCLASSOF, null)
                     // Find the subClassOf properties
                     .objects().stream().map(Resource.class::cast)
+                    .filter(Resource::isIRI) // Ignore blank nodes (usually restrictions)
                     .filter(parentResource -> {
                         if (model.filter(parentResource, null, null).isEmpty()) {
                             //TODO improve error message to include ontology, child class, and missing parent.

--- a/owl-orm-generate/src/test/java/com/realmone/owl/orm/generate/TestGeneratingOntology.java
+++ b/owl-orm-generate/src/test/java/com/realmone/owl/orm/generate/TestGeneratingOntology.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.ModelFactory;
+import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.DynamicModelFactory;
 import org.eclipse.rdf4j.model.impl.ValidatingValueFactory;
@@ -29,6 +30,7 @@ import java.io.Reader;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.Spliterators;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 @Slf4j
@@ -84,7 +86,8 @@ public class TestGeneratingOntology {
                 .useOntologyName("BierOnto")
                 .useReferenceModel(referenceModel)
                 .build();
-        int classCount = model.filter(null, RDF.TYPE, OWL.CLASS).size();
+        int classCount = model.filter(null, RDF.TYPE, OWL.CLASS).subjects().stream()
+                .filter(Resource::isIRI).collect(Collectors.toSet()).size();
         Assert.assertEquals("Expected one generated class per ontology",
                 classCount, ontology.getClassIris().size());
         Assert.assertEquals("Expected bieronto ontology IRI did not match",

--- a/owl-orm-maven-plugin/src/it/simple-it/verify.groovy
+++ b/owl-orm-maven-plugin/src/it/simple-it/verify.groovy
@@ -59,7 +59,7 @@ ontologies.each { ontology ->
     assert thingFile.exists() : "Expected Thing superclass file does not exist: ${thingFile.absolutePath}"
 
     // Extract OWL classes and their dc:title values
-    def classes = rdfModel.filter(null, RDF.TYPE, OWL.CLASS).subjects().collect { subject ->
+    def classes = rdfModel.filter(null, RDF.TYPE, OWL.CLASS).subjects().findAll { subject -> subject.isIRI() }.collect { subject ->
         def title = rdfModel.filter(subject, DCTERMS.TITLE, null).objects().find()?.stringValue()
         def label = rdfModel.filter(subject, RDFS.LABEL, null).objects().find()?.stringValue()
         if (title) {


### PR DESCRIPTION
Added owl:Thing type to Thing interface so that you can create instances of owl:Thing for object properties with no range. Added a helper class called VocabularyIRIs to make IRI instances without a ValueFactory for use in Thing extensions. Adjusted TYPE field generation to create IRIs instead of strings and only when the resource is not a blank node. Added logic to Property to generate static fields for property IRIs as well.